### PR TITLE
Add support for plugin options

### DIFF
--- a/unplugin-macros.js
+++ b/unplugin-macros.js
@@ -10,7 +10,8 @@ const types = {
   '.js': Type.JS,
   '.jsx': Type.JSX,
   '.ts': Type.TS,
-  '.tsx': Type.TSX
+  '.tsx': Type.TSX,
+  '.vue': Type.JS
 };
 
 let assets = new Map();
@@ -18,12 +19,17 @@ let assetsByFile = new Map();
 let packageManager = new NodePackageManager(new NodeFS(), process.cwd());
 let watch = new Map();
 
-module.exports = createUnplugin(() => {
+module.exports = createUnplugin((rawOptions = {}) => {
+  const options = {
+    enforce: 'enforce' in rawOptions ? rawOptions.enforce : 'pre',
+    include: rawOptions.include || /\.(js|jsx|ts|tsx)$/,
+    exclude: rawOptions.exclude || /\/node_modules\//,
+  };
   return {
     name: 'unplugin-macros',
-    enforce: 'pre',
+    enforce: options.enforce,
     transformInclude(id) {
-      return /\.(js|jsx|ts|tsx)$/.test(id) && !id.includes('/node_modules/');
+      return options.include.test(id) && !options.exclude.test(id);
     },
     async transform(code, filePath) {
       if (!/with[\s\n]*\{\s*type:[\s\n]*['"]macro['"][\s\n]*\}/.test(code)) {


### PR DESCRIPTION
This PR adds initial support for providing options to plugin.

Vue support is added so in combination with `include` and `enforce: "post""` script block can be processed for any macros defined in Vue files.

If this should be implemented in separate PR, I can extract it and we can discuss if this should be implemented differently.