### PR TITLE
bump Asyncify buffer asize

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "artifacts": "napi artifacts",
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
-    "build:wasm": "cargo build --target wasm32-unknown-unknown --release && wasm-opt target/wasm32-unknown-unknown/release/unplugin_parcel_macros.wasm --all-features --asyncify --pass-arg=asyncify-imports@env.await_promise_sync -Oz -o unplugin-parcel-macros.wasm",
+    "build:wasm": "cargo build --target wasm32-unknown-unknown --release && wasm-opt target/wasm32-unknown-unknown/release/unplugin_parcel_macros.wasm --all-features --asyncify --pass-arg=asyncify-imports@env.await_promise_sync --pass-arg=asyncify-stack-size@65536 -Oz -o unplugin-parcel-macros.wasm",
     "prepublishOnly": "napi prepublish -t npm",
     "universal": "napi universal",
     "version": "napi version"

--- a/wasm.mjs
+++ b/wasm.mjs
@@ -51,9 +51,9 @@ export async function init() {
 
   // allocate __asyncify_data
   // Stack data goes right after the initial descriptor.
-  let DATA_ADDR = instance.exports.napi_wasm_malloc(8 + 4096);
+  let DATA_ADDR = instance.exports.napi_wasm_malloc(8 + 65536);
   let DATA_START = DATA_ADDR + 8;
-  let DATA_END = DATA_ADDR + 8 + 4096;
+  let DATA_END = DATA_ADDR + 8 + 65536;
   new Int32Array(env.memory.buffer, DATA_ADDR).set([DATA_START, DATA_END]);
 
   function assertNoneState() {


### PR DESCRIPTION
Fixes an issue found in some of our examples running in stackblitz webcontainers: 

```
[plugin:unplugin-macros] unreachable
/home/projects/m9fg5xcr--run/src/Example.tsx
    at wasm://wasm/01c130be:wasm-function[3347]:0x599945
    at await_promise_sync (file:///home/projects/m9fg5xcr--run/node_modules/unplugin-parcel-macros/wasm.mjs:99:5
```

Bumping the Asyncify buffer size up fixes the issue:

Before: https://stackblitz.com/edit/4tntshsg?file=src%2FExample.tsx

After: https://stackblitz.com/edit/cqmykkxj?file=patch-macros.mjs